### PR TITLE
Allow the reference link to be switched off

### DIFF
--- a/class/wpg-admin.class.php
+++ b/class/wpg-admin.class.php
@@ -76,6 +76,7 @@ class WPG_Admin{
 		$alphaarchive = isset( $options['alphaarchive'] ) ? $options['alphaarchive'] : 'standard';
 		$qtipstyle    = isset( $options['qtipstyle'] )    ? $options['qtipstyle']    : 'cream';
 		$termlinkopt  = isset( $options['termlinkopt'] )  ? $options['termlinkopt']  : 'standard';
+		$reflinkopt   = isset( $options['reflinkopt'] )   ? $options['reflinkopt']   : 'on';
 		$termusage    = isset( $options['termusage'] )    ? $options['termusage']    : 'on';
 		$qtiptrigger  = isset( $options['qtiptrigger'] )  ? $options['qtiptrigger']  : 'hover';
 
@@ -144,6 +145,15 @@ class WPG_Admin{
 			),
 		));
 
+		// Term Link HREF target
+		$reflinkoptdropdown = tcb_wpg_build_dropdown( 'reflinkopt', array(
+			'selected' => $reflinkopt,
+			'options'  => array(
+				'on'  => array('title'=>__('On',  'wp-glossary'), 'attrs'=>array('title'=>__('Reference link will be shown', 'wp-glossary'))),
+				'off' => array('title'=>__('Off', 'wp-glossary'), 'attrs'=>array('title'=>__("Don't link to reference",      'wp-glossary'))),
+			),
+		));
+
 		// Term usage
 		$termusagedd = tcb_wpg_build_dropdown( 'termusage', array(
 			'selected' => $termusage,
@@ -173,6 +183,7 @@ class WPG_Admin{
       <div class="inside">
 				<p><?php _e('Archive:', 'wp-glossary'); echo "{$archivedropdown}" ?></p>
 				<p><?php _e('Term link:', 'wp-glossary');  echo "{$termlinkoptdropdown}" ?></p>
+				<p><?php _e('Reference link:', 'wp-glossary');  echo "{$reflinkoptdropdown}" ?></p>
       </div>
      </div>
 
@@ -213,6 +224,7 @@ class WPG_Admin{
 			'alphaarchive' => 'standard',
 			'qtipstyle'    => 'cream',
 			'termlinkopt'  => 'standard',
+			'reflinkopt'   => 'on',
 			'termusage'    => 'on',
 			'qtiptrigger'  => 'hover',
 		);

--- a/class/wpg-post-types.class.php
+++ b/class/wpg-post-types.class.php
@@ -139,8 +139,9 @@ class WPG_Post_types Extends WPG{
 	/** */
 	public function the_content( $content, $is_main_query=1 ){
 		global $post, $wp_query;
-
-		if( $is_main_query && is_single() && 'glossary'==get_post_type() ) :
+		$glossary_options = get_option( 'wp_glossary', array() );
+		$reflinkopt = ! isset($glossary_options['reflinkopt']) || $glossary_options['reflinkopt'] == 'on';
+		if( $reflinkopt && $is_main_query && is_single() && 'glossary'==get_post_type() ) :
 			$options = get_option( 'wp_glossary', array() );
 
 			if( $reference = get_post_meta($post->ID, 'tcbwpg_reference', $single=true) ):


### PR DESCRIPTION
As the reference links are added using a filter, this could mess up some themes.

Since WP-Glossary already allows for single-glossary templates to be created, where one can put the reference wherever one wants, I think this option is a good way to cope with these nasty themes ;)
